### PR TITLE
update hidapi dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "hidapi"
-version = "2.3.3"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f841dbb77615e116fb2ca38044b42310370f0d093c774a72361670ff2ae431b"
+checksum = "723777263b0dcc5730aec947496bd8c3940ba63c15f5633b288cc615f4f6af79"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hidapi = {default-features = false, features = ["linux-static-libusb"]}
+hidapi = { version = "2.4.1", default-features = false, features = ["linux-static-libusb"]}
 pretty-hex = "0.3.0"
 structopt = "0.3.26"


### PR DESCRIPTION
When I was building this repository, I got a warning message from cargo

```
❯ cargo build --release
warning: dependency (hidapi) specified without providing a local path, Git repository, version, or workspace dependency to use. This will be considered an error in future versions
```

To avoid this warning to become an error in the future, I've updated Cargo.toml to the latest version of hidapi package.