### PR TITLE
Add nix flake  script for annepro_tools

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,15 @@
+{ pkgs ? import <nixpkgs> { } }: 
+ let 
+
+   cargoInfo =  builtins.fromTOML (builtins.readFile ./Cargo.toml);
+
+ in pkgs.stdenv.mkDerivation {
+  pname = cargoInfo.package.name;
+  version = cargoInfo.package.version;
+
+  src = ./.;
+
+  buildInputs = with pkgs ; [ libusb1 cargo rustc pkg-config cacert ] ++ lib.optional stdenv.isDarwin [ darwin.apple_sdk.frameworks.AppKit  libiconv];
+  installPhase = ./nix/annepro2-tools-install.sh;
+}
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,57 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-FtPPshEpxH/ewBOsdKBNhlsL2MLEFv1hEnQ19f/bFsQ=",
+        "path": "/nix/store/nmgwv0alk2bi6r87vrxh7wknj23gc2ba-ka3vmkgvsn6cj8dywj7n1xl3bm54gxm7-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "A set of tools to flash an annepro2 keyboard with custom firmware.";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  outputs = { self, nixpkgs, flake-utils } :
+  flake-utils.lib.eachDefaultSystem  (
+    system:
+    let
+      pkgs = nixpkgs.legacyPackages.${system};
+      annepro2tools = pkgs.callPackage ./default.nix { };
+    in
+    {
+
+      packages.annepro2-tools = annepro2tools;
+
+      defaultPackage = annepro2tools;
+
+      devShells.default = pkgs.mkShell {
+        buildInputs = [ annepro2tools ];
+      };
+    }
+    );
+  }
+

--- a/nix/annepro2-tools-install.sh
+++ b/nix/annepro2-tools-install.sh
@@ -1,0 +1,12 @@
+# Create the standard environment.
+source $stdenv/setup
+
+cp -r $src/* ./
+cargo build --release
+
+# Create place to store the binaries.
+mkdir -p $out/bin
+# Copy the binary to the output binary directory.
+cp ./target/release/annepro2_tools $out/bin/annepro2_tools
+# Allow execution of the binary.
+chmod +x $out/bin/annepro2_tools

--- a/nix/annepro2-tools-install.sh
+++ b/nix/annepro2-tools-install.sh
@@ -1,6 +1,8 @@
 # Create the standard environment.
 source $stdenv/setup
 
+
+export HOME=$TEMPDIR
 cp -r $src/* ./
 cargo build --release
 

--- a/readme.md
+++ b/readme.md
@@ -23,14 +23,16 @@ and flash binary starting at 0x4000.
 
 ## nix flake supports
 
+for developer
 
-with flake, you can run `annepro2_tools` directly
+run `nix-shell` to start a rust development shell
 
+run `nix shell` to start new shell for building and testing `annepro2_tools`
+
+with nix flake, you can run `annepro2_tools` directly too.
 
 ```shell
-
 nix run github:OpenAnnePro/AnnePro2-Tools annepro2_tools -- --help
-
 nix run github:OpenAnnePro/AnnePro2-Tools/master annepro2_tools -- --help
 nix run github:OpenAnnePro/AnnePro2-Tools/0.1.0 annepro2_tools -- --help
 nix run github:OpenAnnePro/AnnePro2-Tools annepro2_tools --boot fw.bin

--- a/readme.md
+++ b/readme.md
@@ -20,3 +20,18 @@ To flash file called a.bin you can invoke
 
 By default, the flasher will look for 04d9:8008 (Default Anne Pro 2 IAP)
 and flash binary starting at 0x4000. 
+
+## nix flake supports
+
+
+with flake, you can run `annepro2_tools` directly
+
+
+```shell
+
+nix run github:OpenAnnePro/AnnePro2-Tools annepro2_tools -- --help
+
+nix run github:OpenAnnePro/AnnePro2-Tools/master annepro2_tools -- --help
+nix run github:OpenAnnePro/AnnePro2-Tools/0.1.0 annepro2_tools -- --help
+nix run github:OpenAnnePro/AnnePro2-Tools annepro2_tools --boot fw.bin
+```

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,4 @@
+{ pkgs ? import <nixpkgs> { }
+}: pkgs.mkShell {
+  buildInputs = with pkgs ; [ libusb1 cargo rustc pkg-config cacert ] ++ lib.optional stdenv.isDarwin [ darwin.apple_sdk.frameworks.AppKit libiconv ];
+}


### PR DESCRIPTION
1. be easier to open a dev shell with cargo and rustc
2. Directly run `annepro2_tools` in a nix-installed host
3. install as a package in to a nix host